### PR TITLE
ETD-281: Prepare logging for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_VERSION=0.0.1
 APP_LOG_LEVEL=INFO
 LOG_LEVEL=INFO
 LOG_FILE_BACKUP_COUNT=10
-LOGFILE_PATH =/home/etdadm/logs/etd
+LOGFILE_PATH =/home/etdadm/logs/etd_base_template
 # if set to true, file logging will be turned off
 CONSOLE_LOGGING_ONLY=false 
 CONSUME_QUEUE_NAME=etd_base_template

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,6 @@ LOGFILE_PATH =/home/etdadm/logs/etd
 CONSOLE_LOGGING_ONLY=false 
 CONSUME_QUEUE_NAME=etd_base_template
 PUBLISH_QUEUE_NAME=etd_submission_ready
-JAEGER_NAME="http://localhost:4317"
+JAEGER_NAME="http://jaeger_dashboard:4317"
 JAEGER_SERVICE_NAME=ETD
 BROKER_URL=

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           # GIST_TOKEN is a GitHub personal access token with scope "gist".
           auth: ${{ secrets.GIST_TOKEN }}
-          gistID: 68bd7e7d15e4025d7bf71431bad92771
+          gistID: 2820ee422d89a9fe10cb7fbd4706eeb5
           filename: covbadge.json
           label: Coverage
           message: ${{ env.total }}%

--- a/etd/__init__.py
+++ b/etd/__init__.py
@@ -16,7 +16,8 @@ def configure_logger():  # pragma: no cover
     log_file_path = os.getenv("LOGFILE_PATH",
                               "/home/etdadm/logs/etd_base_template")
     formatter = logging.Formatter(
-                '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                '%(asctime)s - %(name)s - %(levelname)s - ' +
+                '[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s')
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)


### PR DESCRIPTION
**Prepare logging for production.**
* * *

**JIRA Ticket**: (link)


# What does this Pull Request do?
adds class names and line numbers to logs

# How should this be tested?

## Local setup
    
1. Make a copy of the .env.example to .env and modify the user and password variables.

2. Start the container
    
```
docker-compose -f docker-compose-local.yml up -d --build --force-recreate
```

## Testing

1. Start the container up as described in the <b>Local Setup</b> instructions.

2. Exec into the container:

```
docker exec -it etd-base-template bash
```

3. Run the tests

```
pytest
```
4. check the logs:
```
tail -f <CONTAINER_ID>_console_<TIMESTAMP>.log
```

you should see output similar to this:

```
2023-12-14 22:05:53,688 - etd_base_template - INFO - [tasks.py:send_to_base:89] - message
2023-12-14 22:05:53,689 - etd_base_template - INFO - [tasks.py:send_to_base:90] - {'job_ticket_id': 'test_ticket_id', 'unit_test': 'true', 'feature_flags': {'dash_feature_flag': 'off', 'alma_feature_flag': 'off', 'send_to_drs_feature_flag': 'off', 'drs_holding_record_feature_flag': 'off'}, 'identifier': '30522803'}
2023-12-14 22:05:53,850 - etd_base_template - DEBUG - [worker.py:call_api:52] - call.api: REST api is running.
2023-12-14 22:05:53,853 - etd_base_template - DEBUG - [tasks.py:send_to_base:102] - REST api is running.
2023-12-14 22:05:53,863 - etd_base_template - DEBUG - [worker.py:call_api:52] - call.api: REST api is running.
```
if you do then the test was successful.


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
